### PR TITLE
chore(lint): resolve ESLint warnings

### DIFF
--- a/SortVision/eslint.config.mjs
+++ b/SortVision/eslint.config.mjs
@@ -37,9 +37,38 @@ export default [
       ],
       'react-refresh/only-export-components': [
         'warn',
-        { allowConstantExport: true },
+        {
+          allowConstantExport: true,
+          allowExportNames: [
+            'generateMetadata',
+            'generateStaticParams',
+            'metadata',
+            'viewport',
+            'dynamic',
+            'revalidate',
+            'runtime',
+          ],
+        },
       ],
       'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+  {
+    files: ['public/code/**/*.js'],
+    rules: {
+      'no-unused-vars': 'off',
+    },
+  },
+  {
+    files: [
+      'src/context/**/*.{js,jsx}',
+      'src/components/MobileOverlay.jsx',
+      'src/components/seo/LanguageDetection.jsx',
+      'src/components/ui/badge.jsx',
+      'src/components/ui/button.jsx',
+    ],
+    rules: {
+      'react-refresh/only-export-components': 'off',
     },
   },
 ];

--- a/SortVision/server/index.js
+++ b/SortVision/server/index.js
@@ -66,7 +66,4 @@ app.post('/api/gemini', async (req, res) => {
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
   console.log(`✅ Gemini proxy server running on port ${PORT}`);
-  // Log the API key being used (first few characters only)
-  const apiKey = process.env.NEXT_PUBLIC_GEMINI_API_KEY || 'not set';
-  // Do not log API keys, even partially
 });

--- a/SortVision/src/App.jsx
+++ b/SortVision/src/App.jsx
@@ -204,6 +204,7 @@ const MainContent = () => {
     }
   }, [
     location.pathname,
+    pathParts,
     tabFromPath,
     isAlgorithmPath,
     isContributionPath,

--- a/SortVision/src/App.jsx
+++ b/SortVision/src/App.jsx
@@ -91,7 +91,10 @@ const MainContent = () => {
   const fullText = t('main.subtitle');
 
   // Extract tab and algorithm/contribution section from path-based routing
-  const pathParts = location.pathname.split('/').filter(Boolean);
+  const pathParts = useMemo(
+    () => location.pathname.split('/').filter(Boolean),
+    [location.pathname]
+  );
 
   // Handle language prefixes - check if first segment is a language code
   const supportedLanguages = [

--- a/SortVision/src/app/[[...slug]]/page.jsx
+++ b/SortVision/src/app/[[...slug]]/page.jsx
@@ -550,6 +550,6 @@ export async function generateStaticParams() {
   return params;
 }
 
-export default function Page({ params }) {
+export default function Page({ params: _params }) {
   return <ClientOnly />;
 }

--- a/SortVision/src/app/[lang]/sitemap.xml/route.js
+++ b/SortVision/src/app/[lang]/sitemap.xml/route.js
@@ -18,7 +18,7 @@ export async function GET(_request, _params) {
           'Cache-Control': 'public, max-age=3600, s-maxage=3600',
         },
       });
-    } catch (fileError) {
+    } catch {
       // Fallback: Generate a basic sitemap if file doesn't exist
       const baseUrl = 'https://www.sortvision.com';
       const sitemap = `<?xml version="1.0" encoding="UTF-8"?>

--- a/SortVision/src/components/MobileOverlay.jsx
+++ b/SortVision/src/components/MobileOverlay.jsx
@@ -96,7 +96,7 @@ const MobileOverlay = () => {
       window.removeEventListener('orientationchange', handleOrientationChange);
       clearTimeout(orientationTimeout);
     };
-  }, []);
+  }, [setMobileOverlayVisible]);
 
   const handleContinue = () => {
     setAnimationStage(4);

--- a/SortVision/src/components/PWAInstaller.jsx
+++ b/SortVision/src/components/PWAInstaller.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, startTransition } from 'react';
+import React, { useState, useEffect, startTransition } from 'react';
 import { Download, X, Wifi, WifiOff } from 'lucide-react';
 import { Z_INDEX } from '../utils/zIndex';
 
@@ -7,9 +7,6 @@ const PWAInstaller = () => {
   const [showInstallPrompt, setShowInstallPrompt] = useState(false);
   const [isOnline, setIsOnline] = useState(true);
   const [isInstalled, setIsInstalled] = useState(false);
-
-  const timerRef = useRef(null);
-  const fallbackTimerRef = useRef(null);
 
   useEffect(() => {
     // Check if app is already installed
@@ -71,10 +68,7 @@ const PWAInstaller = () => {
       setIsOnline(navigator.onLine);
     });
 
-    // Cleanup
     return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (fallbackTimerRef.current) clearTimeout(fallbackTimerRef.current);
       window.removeEventListener(
         'beforeinstallprompt',
         handleBeforeInstallPrompt
@@ -83,7 +77,7 @@ const PWAInstaller = () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, []);
+  }, [isInstalled]);
 
   const handleInstallClick = async () => {
     if (process.env.NODE_ENV === 'development') {

--- a/SortVision/src/components/chatbot/assistantEngine.js
+++ b/SortVision/src/components/chatbot/assistantEngine.js
@@ -495,7 +495,7 @@ const generateCodeExamples = (algorithmName, language = 'javascript') => {
 };
 
 // Enhanced algorithm recommendation system
-const generateAlgorithmRecommendation = (query, context) => {
+const generateAlgorithmRecommendation = (query, _context) => {
   const lowerQuery = query.toLowerCase();
 
   // Use case based recommendations
@@ -1144,55 +1144,6 @@ export async function processMessage(query, context) {
       };
     }
   }
-}
-
-// Generate responses as separate functions for readability and reusability
-function generateDeveloperResponse() {
-  return `
-        <div class="animate-fade-in animate-duration-100 space-y-1 max-w-full">
-            <p class="m-0 leading-tight break-words">SortVision was created by <span class="text-indigo-400 font-semibold animate-pulse animate-duration-[800ms]">alienX (Prabal Patra)</span>, a passionate developer dedicated to making algorithm learning more interactive and fun! 🚀</p>
-            <div class="flex flex-col sm:flex-row flex-wrap gap-2 text-sm mt-1">
-                <a href="https://github.com/alienx5499" target="_blank" class="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-emerald-400 text-emerald-300 hover:bg-emerald-400/10 transition-all duration-150">
-                    🐙 GitHub
-                </a>
-                <a href="https://www.linkedin.com/in/prabalpatra5499/" target="_blank" class="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-blue-400 text-blue-300 hover:bg-blue-400/10 transition-all duration-150">
-                    💼 LinkedIn
-                </a>
-                <a href="https://x.com/alienx5499" target="_blank" class="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-sky-400 text-sky-300 hover:bg-sky-400/10 transition-all duration-150">
-                    🐦 Twitter
-                </a>
-            </div>
-        </div>`;
-}
-
-function generateSupportResponse() {
-  return `
-        <div class="animate-fade-in animate-duration-150 space-y-0.5 max-w-full">
-            <p class="m-0 leading-tight break-words">Thank you for considering supporting SortVision! 💖</p>
-            <div class="flex flex-col gap-2 mt-1">
-                <a href="https://github.com/alienx5499/SortVision" target="_blank" class="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-yellow-400 text-yellow-300 hover:bg-yellow-400/10 transition-all duration-150 text-sm">
-                    ⭐ Star on GitHub
-                </a>
-                <a href="https://github.com/sponsors/alienx5499" target="_blank" class="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-pink-400 text-pink-300 hover:bg-pink-400/10 transition-all duration-150 text-sm">
-                    ♥ Sponsor on GitHub
-                </a>
-                <a href="https://buymeacoffee.com/alienx5499" target="_blank" class="inline-flex items-center gap-1 px-3 py-2 rounded-md border border-yellow-500 text-yellow-400 hover:bg-yellow-500/10 transition-all duration-150 text-sm">
-                    ☕ Buy me a coffee
-                </a>
-            </div>
-            <p class="m-0 text-xs text-slate-400 animate-pulse animate-duration-[1000ms] break-words">Your support helps keep SortVision free and improving! 🙏</p>
-        </div>`;
-}
-
-function generateGithubResponse() {
-  return `
-        <div class="animate-fade-in animate-duration-150 space-y-0.5 max-w-full">
-            <p class="m-0 leading-tight break-words">You can find SortVision on GitHub <a href="https://github.com/alienx5499/SortVision" target="_blank" class="text-blue-400 hover:text-blue-300 underline transition-colors duration-150">here</a>!</p>
-            <div class="animate-bounce animate-duration-[1000ms]">
-                <p class="text-sm break-words">If you find this project helpful, please give it a ⭐️ star on GitHub!</p>
-            </div>
-            <p class="m-0 text-xs text-slate-400 break-words">Your support helps us grow and improve! 🙏</p>
-        </div>`;
 }
 
 function generateThankYouResponse() {

--- a/SortVision/src/components/feedback/FeedbackModal.jsx
+++ b/SortVision/src/components/feedback/FeedbackModal.jsx
@@ -130,6 +130,7 @@ const FeedbackModal = ({ isOpen, onClose }) => {
     if (isOpen && !locationData) {
       detectUserLocationEnhanced();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run when modal opens; including locationData or the detector would loop or churn
   }, [isOpen]);
 
   // Track time spent on site
@@ -361,8 +362,7 @@ const FeedbackModal = ({ isOpen, onClose }) => {
           if (storedErrors) {
             errors.push(...JSON.parse(storedErrors));
           }
-        } catch (_e) {
-          // eslint-disable-line no-unused-vars
+        } catch {
           // Ignore localStorage errors
         }
         return errors.slice(-5); // Last 5 errors
@@ -372,8 +372,7 @@ const FeedbackModal = ({ isOpen, onClose }) => {
         try {
           const usage = localStorage.getItem('sortvision_feature_usage');
           return usage ? JSON.parse(usage) : null;
-        } catch (_e) {
-          // eslint-disable-line no-unused-vars
+        } catch {
           return null;
         }
       };

--- a/SortVision/src/components/feedback/githubService.js
+++ b/SortVision/src/components/feedback/githubService.js
@@ -468,8 +468,7 @@ ${formatErrorHistory(feedbackData.errorHistory)}
       let errorData;
       try {
         errorData = await response.json();
-      } catch (parseError) {
-        // eslint-disable-line no-unused-vars
+      } catch {
         errorData = {
           message: `HTTP ${response.status}: ${response.statusText}`,
         };

--- a/SortVision/src/components/feedback/locationService.js
+++ b/SortVision/src/components/feedback/locationService.js
@@ -93,8 +93,7 @@ export const detectUserLocation = async () => {
 /**
  * Primary service: IP-API.com (free, reliable, detailed)
  */
-const detectWithIPApi = async () => {
-  // eslint-disable-line no-unused-vars
+const _detectWithIPApi = async () => {
   const response = await fetch(
     'https://ip-api.com/json/?fields=status,message,country,countryCode,region,regionName,city,lat,lon,timezone,isp,org,as,query',
     {
@@ -133,8 +132,7 @@ const detectWithIPApi = async () => {
 /**
  * Secondary service: IPInfo.io (reliable, good coverage)
  */
-const detectWithIPInfo = async () => {
-  // eslint-disable-line no-unused-vars
+const _detectWithIPInfo = async () => {
   const response = await fetch('https://ipinfo.io/json', {
     timeout: 5000,
   });
@@ -168,8 +166,7 @@ const detectWithIPInfo = async () => {
 /**
  * Third service: IPGeolocation.io (backup service)
  */
-const detectWithIPGeolocation = async () => {
-  // eslint-disable-line no-unused-vars
+const _detectWithIPGeolocation = async () => {
   const response = await fetch(
     'https://api.ipgeolocation.io/ipgeo?apiKey=free',
     {
@@ -204,8 +201,7 @@ const detectWithIPGeolocation = async () => {
 /**
  * Fourth service: FreeGeoIP (simple fallback)
  */
-const detectWithFreeGeoIP = async () => {
-  // eslint-disable-line no-unused-vars
+const _detectWithFreeGeoIP = async () => {
   const response = await fetch('https://freegeoip.app/json/', {
     timeout: 5000,
   });

--- a/SortVision/src/components/panels/metrics/CurrentRunMetrics.jsx
+++ b/SortVision/src/components/panels/metrics/CurrentRunMetrics.jsx
@@ -51,26 +51,6 @@ const CurrentRunMetrics = ({ metrics, sortedMetrics, algorithm, array }) => {
         )
       : 0;
 
-  // Get algorithm color based on efficiency
-  const getAlgorithmColor = algo => {
-    // eslint-disable-line no-unused-vars
-    switch (algo) {
-      case 'quick':
-      case 'merge':
-      case 'heap':
-        return 'text-green-500 hover:text-green-400';
-      case 'radix':
-      case 'bucket':
-        return 'text-cyan-500 hover:text-cyan-400';
-      case 'insertion':
-      case 'selection':
-      case 'bubble':
-        return 'text-red-500 hover:text-red-400';
-      default:
-        return 'text-slate-400 hover:text-slate-300';
-    }
-  };
-
   return (
     <div className="bg-slate-900 p-4 rounded border border-slate-800 relative overflow-hidden group">
       {/* Animated gradient background */}

--- a/SortVision/src/utils/audioEngine.js
+++ b/SortVision/src/utils/audioEngine.js
@@ -210,8 +210,7 @@ class AudioEngine {
     }
   }
 
-  playSound(frequency, type, duration, value = null) {
-    // eslint-disable-line no-unused-vars
+  playSound(frequency, type, duration, _value = null) {
     // *** AUDIO DISABLED *** - All sounds are muted while keeping UI functional
     console.log(
       'AudioEngine: Audio playback disabled - sound muted but UI remains functional'


### PR DESCRIPTION
This Pull Request clears ESLint warnings across the SortVision app and tightens ESLint config so `pnpm lint` passes cleanly.

It changes the following:

- **ESLint:** Turn off `react-refresh/only-export-components` for context, shadcn UI, `MobileOverlay`, and `LanguageDetection` (multi-export patterns that are intentional).
- **ESLint:** Allow Next.js App Router export names (`generateMetadata`, `generateStaticParams`, etc.) where applicable.
- **Code:** Fix or silence unused vars/catches, hook dependency notes, and remove dead `getAlgorithmColor` in `CurrentRunMetrics`; small tweaks in `App`, `PWAInstaller`, `MobileOverlay`, feedback/chatbot utilities, and public algorithm snippets.

## Testing

- `cd SortVision && pnpm run format:check && pnpm run lint && pnpm run test:unit`