### PR TITLE
feat(algorithms): retain intentional react-doctor disable comments

### DIFF
--- a/SortVision/src/algorithms/bubbleSort.ts
+++ b/SortVision/src/algorithms/bubbleSort.ts
@@ -24,6 +24,7 @@ export const bubbleSort: SortingAlgorithm = async (
       comparisons++;
       setCurrentBar({ compare: j, swap: j + 1 });
       audio.playCompareSound(arr[j]);
+      // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
       await delayStep(delay, delayRefs);
 
       if (arr[j] > arr[j + 1]) {
@@ -31,6 +32,7 @@ export const bubbleSort: SortingAlgorithm = async (
         swaps++;
         audio.playSwapSound(arr[j]);
         visualizeArray([...arr]);
+        // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
         await delayStep(delay, delayRefs);
       }
     }

--- a/SortVision/src/algorithms/bucketSort.ts
+++ b/SortVision/src/algorithms/bucketSort.ts
@@ -83,6 +83,7 @@ export const bucketSort: SortingAlgorithm = async (
     setCurrentBar({ compare: i, swap: null });
     visualizeArray([...array]);
     audio.playAccessSound(array[i]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
   }
 
@@ -91,6 +92,7 @@ export const bucketSort: SortingAlgorithm = async (
       setCurrentBar({ compare: null, swap: null });
       return metrics;
     }
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await insertionSortBucket(buckets[i], shouldStopRef, audio, metrics);
   }
 
@@ -106,6 +108,7 @@ export const bucketSort: SortingAlgorithm = async (
       setCurrentBar({ compare: null, swap: index });
       visualizeArray([...array]);
       audio.playAccessSound(array[index]);
+      // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
       await delayStep(delay, delayRefs);
       index++;
     }

--- a/SortVision/src/algorithms/heapSort.ts
+++ b/SortVision/src/algorithms/heapSort.ts
@@ -60,6 +60,7 @@ async function heapify(
     visualizeArray([...arr]);
     await delayStep(delay, delayRefs);
 
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await heapify(
       arr,
       n,
@@ -92,6 +93,7 @@ export const heapSort: SortingAlgorithm = async (
     if (shouldStopRef.current) {
       return metrics;
     }
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await heapify(
       arr,
       n,
@@ -114,8 +116,10 @@ export const heapSort: SortingAlgorithm = async (
     metrics.swaps++;
     audio.playSwapSound(arr[0]);
     visualizeArray([...arr]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
 
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await heapify(
       arr,
       i,

--- a/SortVision/src/algorithms/insertionSort.ts
+++ b/SortVision/src/algorithms/insertionSort.ts
@@ -27,12 +27,14 @@ export const insertionSort: SortingAlgorithm = async (
       comparisons++;
       setCurrentBar({ compare: j, swap: j + 1 });
       audio.playCompareSound(arr[j]);
+      // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
       await delayStep(delay, delayRefs);
 
       arr[j + 1] = arr[j];
       swaps++;
       audio.playSwapSound(arr[j]);
       visualizeArray([...arr]);
+      // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
       await delayStep(delay, delayRefs);
 
       j--;
@@ -40,6 +42,7 @@ export const insertionSort: SortingAlgorithm = async (
 
     arr[j + 1] = key;
     visualizeArray([...arr]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
   }
 

--- a/SortVision/src/algorithms/mergeSort.ts
+++ b/SortVision/src/algorithms/mergeSort.ts
@@ -35,6 +35,7 @@ async function merge(
     metrics.comparisons++;
     setCurrentBar({ compare: left + i, swap: mid + 1 + j });
     audio.playCompareSound(leftArr[i]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
 
     if (leftArr[i] <= rightArr[j]) {
@@ -48,6 +49,7 @@ async function merge(
 
     audio.playMergeSound(arr[k]);
     visualizeArray([...arr]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
     k++;
   }
@@ -59,6 +61,7 @@ async function merge(
     arr[k] = leftArr[i];
     audio.playMergeSound(arr[k]);
     visualizeArray([...arr]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
     i++;
     k++;
@@ -71,6 +74,7 @@ async function merge(
     arr[k] = rightArr[j];
     audio.playMergeSound(arr[k]);
     visualizeArray([...arr]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
     j++;
     k++;

--- a/SortVision/src/algorithms/quickSort.ts
+++ b/SortVision/src/algorithms/quickSort.ts
@@ -34,6 +34,7 @@ async function partition(
     metrics.comparisons++;
     setCurrentBar({ compare: j, swap: high });
     audio.playCompareSound(arr[j]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
 
     if (arr[j] < pivot) {

--- a/SortVision/src/algorithms/radixSort.ts
+++ b/SortVision/src/algorithms/radixSort.ts
@@ -32,6 +32,7 @@ async function countingSort(
     setCurrentBar({ compare: i, swap: null });
     audio.playCompareSound(arr[i]);
     count[Math.floor(arr[i] / exp) % 10]++;
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
   }
 
@@ -46,6 +47,7 @@ async function countingSort(
     visualizeArray([...output]);
     setCurrentBar({ compare: i, swap: null });
     audio.playAccessSound(arr[i]);
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await delayStep(delay, delayRefs);
 
     if (delayRefs.shouldStopRef.current) {
@@ -84,6 +86,7 @@ export const radixSort: SortingAlgorithm = async (
   let exp = 1;
 
   while (Math.floor(max / exp) > 0) {
+    // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
     await countingSort(
       array,
       exp,

--- a/SortVision/src/algorithms/selectionSort.ts
+++ b/SortVision/src/algorithms/selectionSort.ts
@@ -26,6 +26,7 @@ export const selectionSort: SortingAlgorithm = async (
       comparisons++;
       setCurrentBar({ compare: minIndex, swap: j });
       audio.playCompareSound(arr[j]);
+      // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
       await delayStep(delay, delayRefs);
 
       if (arr[j] < arr[minIndex]) {
@@ -38,6 +39,7 @@ export const selectionSort: SortingAlgorithm = async (
       swaps++;
       audio.playSwapSound(arr[i]);
       visualizeArray([...arr]);
+      // react-doctor-disable-next-line -- intentionally sequential for visualization, react-doctor/async-await-in-loop
       await delayStep(delay, delayRefs);
     }
   }


### PR DESCRIPTION
Sorting algorithms require sequential await for step-by-step visualization. Each comparison must wait for the previous delay to complete before starting the next. Promise.all() would run all comparisons instantly, breaking the visualization feature.

The disable comments document the intentional design decision rather than hiding the bypass. Core algorithms remain unchanged.